### PR TITLE
Added support for frame step.

### DIFF
--- a/operators/rendergif.py
+++ b/operators/rendergif.py
@@ -170,7 +170,7 @@ class SEQUENCER_OT_render_gif(bpy.types.Operator, ExportHelper):
 
         if event.type == 'TIMER':
             try:
-                frame_count = scene.frame_end - scene.frame_start + 1
+                frame_count = (scene.frame_end - scene.frame_start) / scene.frame_step + 1
                 if len(os.listdir(frames_folder)) == frame_count:
 
                     self.make_gif(context)

--- a/operators/rendergif.py
+++ b/operators/rendergif.py
@@ -170,7 +170,7 @@ class SEQUENCER_OT_render_gif(bpy.types.Operator, ExportHelper):
 
         if event.type == 'TIMER':
             try:
-                frame_count = (scene.frame_end - scene.frame_start) / scene.frame_step + 1
+                frame_count = int((scene.frame_end - scene.frame_start) / scene.frame_step + 1)
                 if len(os.listdir(frames_folder)) == frame_count:
 
                     self.make_gif(context)


### PR DESCRIPTION
When frame step is used under Output Properties > Dimensions render ends up in infinite loop because there are less files in folder than whats calculated because some are skipped.